### PR TITLE
fix: 💚 fix Swift test build with latest aws-sdk-swift DynamoDB config API

### DIFF
--- a/Tests/EventStoreAdapterTests/EventStoreImplTests.swift
+++ b/Tests/EventStoreAdapterTests/EventStoreImplTests.swift
@@ -161,14 +161,14 @@ where
             return handler
         }
         let logger = Logger(label: "EventStoreForDynamoDBTests.test")
-        let client = try await DynamoDBClient(
-            config: .init(
-                ignoreConfiguredEndpointURLs: true,
-                region: "ap-northeast-1",
-                endpoint: "http://localhost:8001",
-                httpClientEngine: ClientConfigurationDefaults.makeClient(
-                    httpClientConfiguration: .init(protocolType: .http))
-            ))
+        let config = try await DynamoDBClient.DynamoDBClientConfig(
+            ignoreConfiguredEndpointURLs: true,
+            region: "ap-northeast-1",
+            endpoint: "http://localhost:8001",
+            httpClientEngine: ClientConfigurationDefaults.makeClient(
+                httpClientConfiguration: .init(protocolType: .http))
+        )
+        let client = DynamoDBClient(config: config)
 
         let testTimeFactor =
             ProcessInfo.processInfo.environment["TEST_TIME_FACTOR"].flatMap(TimeInterval.init) ?? 1
@@ -176,7 +176,7 @@ where
         let journalTableName = "journal"
         let journalAidIndexName = "journal-aid-index"
         while try await waitTable(client: client, targetTableName: journalTableName) {
-            _ = try? await client.deleteTable(input: .init(tableName: journalTableName))
+            _ = try? await client.deleteTable(input: DeleteTableInput(tableName: journalTableName))
             try await Task.sleep(nanoseconds: UInt64(testTimeFactor) * 1_000_000_00)
         }
         try await createJournalTable(
@@ -186,7 +186,7 @@ where
         let snapshotTableName = "snapshot"
         let snapshotAidIndexName = "snapshot-aid-index"
         while try await waitTable(client: client, targetTableName: snapshotTableName) {
-            _ = try? await client.deleteTable(input: .init(tableName: snapshotTableName))
+            _ = try? await client.deleteTable(input: DeleteTableInput(tableName: snapshotTableName))
             try await Task.sleep(nanoseconds: UInt64(testTimeFactor) * 1_000_000_00)
         }
         try await createSnapshotTable(


### PR DESCRIPTION
## Summary
This PR fixes the Swift test build failure caused by API changes in newer `aws-sdk-swift` releases.

## Root Cause
`EventStoreImplTests` initialized the DynamoDB client using `DynamoDBClient.Config` (a deprecated typealias) with `.init(...)` inference.
With the latest SDK, overlapping sync/async initializers with the same labels make that usage ambiguous in Swift 6.2.
In the same test, `deleteTable(input: .init(...))` also relied on contextual type inference that no longer resolved reliably.

## Changes
- Replaced ambiguous config initialization with explicit, modern API usage:
  - `let config = try await DynamoDBClient.DynamoDBClientConfig(...)`
  - `let client = DynamoDBClient(config: config)`
- Replaced inferred delete input construction with explicit types:
  - `DeleteTableInput(tableName: ...)`

## Why This Fix Works
By making the config type and async initializer explicit, Swift no longer needs to guess between overloaded initializers.
Using `DeleteTableInput` explicitly removes contextual inference ambiguity for DynamoDB operations.

## Validation
- `swift format lint -s --configuration .swift-format -r Sources Tests Package.swift`
- `swift build`
- `swift test`
- `SMALL=true swift test`

## Scope / Impact
- Test code only (`Tests/EventStoreAdapterTests/EventStoreImplTests.swift`)
- No production runtime behavior changes
